### PR TITLE
Fix: 单个用户的并发会话限制

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+util-linux (2.40.4-3deepin5) unstable; urgency=medium
+
+  * fix var/run/utmp don't be updated after login
+
+ -- jiahao.luo <luojiahao@uniontech.com>  Fri, 16 May 2025 17:14:50 +0800
+
 util-linux (2.40.4-3deepin4) unstable; urgency=medium
 
   * backward old version lsblk for show hotplug flag bug.

--- a/debian/patches/debian/login-turn-on-utmp-writing.patch
+++ b/debian/patches/debian/login-turn-on-utmp-writing.patch
@@ -1,0 +1,12 @@
+Index: util-linux/login-utils/login.c
+===================================================================
+--- util-linux.orig/login-utils/login.c
++++ util-linux/login-utils/login.c
+@@ -1494,6 +1494,7 @@ int main(int argc, char **argv)
+ 	endpwent();
+ 
+ 	log_audit(&cxt, 1);
++	log_utmp(&cxt);
+ 
+ 	chown_tty(&cxt);
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -25,3 +25,4 @@ upstream-master/fallocate-forbid-posix-with-special-options.patch
 upstream-master/lib-colors-fix-fallback-to-system-directory.patch
 debian/usec-umac-adapt.patch
 uniontech-backward-lsblk.patch
+debian/login-turn-on-utmp-writing.patch


### PR DESCRIPTION
由于pam_limits库通过读取 var/run/utmp 文件进行判断并发会话数量，而login后 utmp 文件并没有更新，故添加更新逻辑

## Summary by Sourcery

Enable utmp logging on user login to fix per-user concurrent session limit enforcement by pam_limits.

Bug Fixes:
- Ensure utmp is updated upon login so pam_limits properly counts concurrent sessions.

Build:
- Add a Debian patch to enable utmp writing in the login package.