### PR TITLE
Fix: fix CVE-2025-14104

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+util-linux (2.40.4-3deepin9) unstable; urgency=medium
+
+  * fix CVE-2025-14104 
+
+ -- zengwei <zengwei1@uniontech.com>  Thu, 25 Dec 2025 15:02:15 +0800
+
 util-linux (2.40.4-3deepin8) unstable; urgency=medium
 
   * fix lscpu wrong at Phytium.

--- a/debian/patches/CVE-2025-14104-1.patch
+++ b/debian/patches/CVE-2025-14104-1.patch
@@ -1,0 +1,30 @@
+From aaa9e718c88d6916b003da7ebcfe38a3c88df8e6 Mon Sep 17 00:00:00 2001
+From: Mohamed Maatallah <hotelsmaatallahrecemail@gmail.com>
+Date: Sat, 24 May 2025 03:16:09 +0100
+Subject: [PATCH] Update setpwnam.c
+
+---
+ login-utils/setpwnam.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/login-utils/setpwnam.c b/login-utils/setpwnam.c
+index 3e3c1abde50..95e470b5a34 100644
+--- a/login-utils/setpwnam.c
++++ b/login-utils/setpwnam.c
+@@ -126,10 +126,12 @@ int setpwnam(struct passwd *pwd, const char *prefix)
+ 		}
+ 
+ 		/* Is this the username we were sent to change? */
+-		if (!found && linebuf[namelen] == ':' &&
+-		    !strncmp(linebuf, pwd->pw_name, namelen)) {
+-			/* Yes! So go forth in the name of the Lord and
+-			 * change it!  */
++		if (!found &&
++		    strncmp(linebuf, pwd->pw_name, namelen) == 0 &&
++		    strlen(linebuf) > namelen &&
++		    linebuf[namelen] == ':') {
++			/* Yes! But this time let’s not walk past the end of the buffer
++			 * in the name of the Lord, SUID, or anything else. */
+ 			if (putpwent(pwd, fp) < 0)
+ 				goto fail;
+ 			found = 1;

--- a/debian/patches/CVE-2025-14104-2.patch
+++ b/debian/patches/CVE-2025-14104-2.patch
@@ -1,0 +1,24 @@
+From 9a36d77012c4c771f8d51eba46b6e62c29bf572a Mon Sep 17 00:00:00 2001
+From: Mohamed Maatallah <hotelsmaatallahrecemail@gmail.com>
+Date: Mon, 26 May 2025 10:06:02 +0100
+Subject: [PATCH] Update bufflen
+
+Update buflen
+---
+ login-utils/setpwnam.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/login-utils/setpwnam.c b/login-utils/setpwnam.c
+index 95e470b5a34..7778e98f7cc 100644
+--- a/login-utils/setpwnam.c
++++ b/login-utils/setpwnam.c
+@@ -99,7 +99,8 @@ int setpwnam(struct passwd *pwd, const char *prefix)
+ 		goto fail;
+ 
+ 	namelen = strlen(pwd->pw_name);
+-
++	if (namelen > buflen)
++		buflen += namelen;
+ 	linebuf = malloc(buflen);
+ 	if (!linebuf)
+ 		goto fail;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -27,3 +27,6 @@ debian/usec-umac-adapt.patch
 uniontech-backward-lsblk.patch
 add-sunway-support.patch
 uniontech-fix-arm-lscpu-modename.patch
+CVE-2025-14104-1.patch
+CVE-2025-14104-2.patch
+


### PR DESCRIPTION
Fix: fix CVE-2025-14104

## Summary by Sourcery

Address CVE-2025-14104 in the Debian packaging by adding security patches and updating the changelog and patch series.

Bug Fixes:
- Apply Debian patches to fix security vulnerability CVE-2025-14104 in the packaged software.

Chores:
- Update Debian changelog and patch series to reference the new CVE-2025-14104 fix patches.