### PR TITLE
fix: backport upstream bug fixes from util-linux

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+util-linux (2.40.4-3deepin10) unstable; urgency=medium
+
+  * Backport upstream bug fixes:
+  * c88bf7ff: agetty: fix path_cxt leak in credential loading
+  * 47645c45: pipesz: fix duplicate error message on invalid options
+
+ -- jiabowen <jiabowen@uniontech.com>  Tue, 26 May 2026 20:14:58 +0800
+
 util-linux (2.40.4-3deepin9) unstable; urgency=medium
 
   * fix CVE-2025-14104 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -30,3 +30,5 @@ uniontech-fix-arm-lscpu-modename.patch
 CVE-2025-14104-1.patch
 CVE-2025-14104-2.patch
 
+upstream-master/agetty-fix-path_cxt-leak-credential-loading.patch
+upstream-master/pipesz-fix-duplicate-error-getopt-merge.patch

--- a/debian/patches/upstream-master/agetty-fix-path_cxt-leak-credential-loading.patch
+++ b/debian/patches/upstream-master/agetty-fix-path_cxt-leak-credential-loading.patch
@@ -1,0 +1,20 @@
+Index: util-linux-worktree/term-utils/agetty.c
+===================================================================
+--- util-linux-worktree.orig/term-utils/agetty.c
++++ util-linux-worktree/term-utils/agetty.c
+@@ -3027,7 +3027,7 @@ static void load_credentials(struct opti
+ 	dir = ul_path_opendir(pc, NULL);
+ 	if (!dir) {
+ 		log_warn(_("failed to open credentials directory"));
+-		return;
++		goto out;
+ 	}
+ 
+ 	while ((d = xreaddir(dir))) {
+@@ -3040,4 +3040,6 @@ static void load_credentials(struct opti
+ 		}
+ 	}
+ 	closedir(dir);
++out:
++	ul_unref_path(pc);
+ }

--- a/debian/patches/upstream-master/pipesz-fix-duplicate-error-getopt-merge.patch
+++ b/debian/patches/upstream-master/pipesz-fix-duplicate-error-getopt-merge.patch
@@ -1,0 +1,53 @@
+From 47645c455e785857e9d8eb131ea11de6a1df61c3 Mon Sep 17 00:00:00 2001
+From: Karel Zak <kzak@redhat.com>
+Date: Mon, 25 May 2026 13:33:34 +0200
+Subject: [PATCH] pipesz: merge help/version getopt loop into main loop
+
+The main() function scanned command-line options in two passes: the
+first pass checked for --help/--version, and the second processed
+normal options. When getopt_long encountered an unknown option in the
+first pass, it printed an error message. The same error was then
+printed again during the second pass, resulting in a duplicate
+"unrecognized option" message.
+
+Fix this by merging the first getopt_long loop into the main one,
+following the standard util-linux convention.
+
+Fixes: https://github.com/util-linux/util-linux/issues/3817
+Signed-off-by: Karel Zak <kzak@redhat.com>
+
+Index: util-linux-worktree/misc-utils/pipesz.c
+===================================================================
+--- util-linux-worktree.orig/misc-utils/pipesz.c
++++ util-linux-worktree/misc-utils/pipesz.c
+@@ -228,18 +228,6 @@ int main(int argc, char **argv)
+ 	textdomain(PACKAGE);
+ 	close_stdout_atexit();
+ 
+-	/* check for --help or --version */
+-	while ((c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1) {
+-		switch (c) {
+-		case 'h':
+-			usage();
+-		case 'V':
+-			print_version(EXIT_SUCCESS);
+-		}
+-	}
+-
+-	/* gather normal options */
+-	optind = 1;
+ 	while ((c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1) {
+ 		err_exclusive_options(c, longopts, excl, excl_st);
+ 
+@@ -277,6 +265,11 @@ int main(int argc, char **argv)
+ 		case 'v':
+ 			opt_verbose = TRUE;
+ 			break;
++
++		case 'V':
++			print_version(EXIT_SUCCESS);
++		case 'h':
++			usage();
+ 		default:
+ 			errtryhelp(EXIT_FAILURE);
+ 		}


### PR DESCRIPTION
## Summary

Backport important bug fixes from upstream util-linux master (2026-05-20 ~ 2026-05-26).

### Changes

| Patch | Category | Description |
|-------|----------|-------------|
| [c88bf7ff](https://github.com/util-linux/util-linux/commit/c88bf7ff7aafa2129d76d6b6395e4b250aa92dcf) | Bug Fix | agetty: fix path\_cxt memory leak in credential loading |
| [47645c45](https://github.com/util-linux/util-linux/commit/47645c455e785857e9d8eb131ea11de6a1df61c3) | Bug Fix | pipesz: fix duplicate error message on invalid options |

### Skipped (not applicable to local codebase)

| Commit | Reason |
|--------|--------|
| [989169ed](https://github.com/util-linux/util-linux/commit/989169ed4d306032fb3ae967fd90fedf1b168041) | Upstream refactored agetty into multi-file architecture; new header `agetty-cmd/agetty.h` does not exist in local monolithic codebase |
| [618ef24a](https://github.com/util-linux/util-linux/commit/618ef24a662b1fe8a19f9f7e9cd4630f28a8d601) + sub-commits | Local util-linux 2.40.4 lacks DASD partition table support (`libblkid/src/partitions/dasd.c` absent); DASD is s390-architecture specific |

### Details

- **agetty path\_cxt leak**: The `ul_new_path()` result in `load_credentials()` was never freed on error paths. Fixed by adding `goto out` with `ul_unref_path(pc)`. Adapted manually since upstream refactored agetty into `agetty-cmd/credentials.c` while local code uses monolithic `term-utils/agetty.c`.
- **pipesz duplicate error**: Merged duplicate getopt loops into single loop, eliminating double "unrecognized option" error output. Applied with fuzz=1, refreshed.

### Testing

- `quilt push -a` / `quilt refresh` verified all patches apply cleanly
- Only `debian/` directory modified

### Generated-By

glm-5-turbo
